### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes
 3.0 (unreleased)
 ================
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Add support for Python 3.12, 3.13.
 
 - Drop support for Python 3.7, 3.8.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,7 +2,7 @@
 Changes
 =======
 
-2.1 (unreleased)
+3.0 (unreleased)
 ================
 
 - Add support for Python 3.12, 3.13.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 """
 import os.path
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -63,8 +62,6 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
     ],
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
     include_package_data=True,
     python_requires='>=3.9',
     install_requires=[
@@ -80,14 +77,13 @@ setup(
         'zope.publisher',
         'zope.schema',
     ],
-    namespace_packages=['zc'],
     extras_require={
         'test': [
             'zope.component[zcml]',
             'persistent >= 4.4.3',
             'zope.site',
             'zope.testing',
-            'zope.testrunner',
+            'zope.testrunner >= 6.4',
             'zope.keyreference',
         ]},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read_file(*args):
 
 setup(
     name='zc.sourcefactory',
-    version='2.1.dev0',
+    version='3.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
     url='https://github.com/zopefoundation/zc.sourcefactory',

--- a/src/zc/__init__.py
+++ b/src/zc/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
